### PR TITLE
Use bin not bin64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bin/*
 bin64/*
+demo/*

--- a/util/Directories.s2s
+++ b/util/Directories.s2s
@@ -20,14 +20,15 @@ var tmp$;
 '    bin$ := View(App(3)).FileName$(1) + View(App(3)).FileName$(2) + "..\\bin";	' Location of executables is ..\bin, relative to script dir
 'endif
 
-if System$("PROCESSOR_ARCHITECTURE") = "AMD64" then
-    bin$ := View(App(3)).FileName$(1) + View(App(3)).FileName$(2) + "..\\bin64";
-    PrintLog("64-bit platform detected, using bin$=\n" + bin$);
-else
-    bin$ := View(App(3)).FileName$(1) + View(App(3)).FileName$(2) + "..\\bin";
-    PrintLog("32-bit platform detected, using bin$=\n" + bin$);
-endif
+'if System$("PROCESSOR_ARCHITECTURE") = "AMD64" then
+'    bin$ := View(App(3)).FileName$(1) + View(App(3)).FileName$(2) + "..\\bin64";
+'    PrintLog("64-bit platform detected, using bin$=\n" + bin$);
+'else
+'    bin$ := View(App(3)).FileName$(1) + View(App(3)).FileName$(2) + "..\\bin";
+'    PrintLog("32-bit platform detected, using bin$=\n" + bin$);
+'endif
 
+bin$ := View(App(3)).FileName$(1) + View(App(3)).FileName$(2) + "..\\bin";
 
 script$ := View(App(3)).FileName$(1) + View(App(3)).FileName$(2);	' folder containing this script
 'util$ := View(App(3)).FileName$(1) + View(App(3)).FileName$(2) + "..\\..\\Spike2Util";


### PR DESCRIPTION
I'd like to change usrig scripts to use only the binary folder usrig/bin. This folder us used to find fixstim.exe and remote.exe, and any other exe files we use. 

GetBinDir$() used to check architecture. That was because the dichoptic rig had to have a 32 bit machine and a 64 bit machine, and they used different executables. I needed a way to make the scripts work seamlessly without having to potentially have 32&64 bit exes in same location. That no longer applies - all our vsg exe must be 32 bit because of the ASL dll (which is 32 bit). 

We should simultaneously remove the usrig/bin64 folder so that any scripts out there that don't use GetBinDir$() will fail. 

Do you think there are any other scripts with hard-coded bin paths? 